### PR TITLE
docker: use maintainer label

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3-alpine
-MAINTAINER Stamatis Katsaounis "skatsaounis@admin.grnet.gr"
+LABEL maintainer="skatsaounis@admin.grnet.gr"
 
 ARG BRANCH=master
 


### PR DESCRIPTION
The MAINTAINER directive is deprecated in favor of the LABEL
directive (https://docs.docker.com/engine/reference/builder/#maintainer-deprecated).