### PR TITLE
Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,6 @@ conventions must be made:
 1. A node object in MaaS must have the same name in NetBox (case
 insensitive)
 
-## Limitations
-At the moment, MaaS2Netbox support only Lenovo hardware nodes.
-
 ## Known Issues
 The following issues have been recorded and they will be fixed in newer
 versions of MaaS2Netbox:


### PR DESCRIPTION
Remove old limitation section for Lenovo nodes. This part was a leftover from a previous version of maas2netbox when IPMI information could be retrieved directly from IPMI interface of the bare metal nodes. Since that feature was not part of fetching information from MaaS to Netbox, it was removed with (#16).

Resolves (#19)